### PR TITLE
fix: 如月车站，微信WechatProvider无法正确提取到成绩的bug

### DIFF
--- a/maimai_py/utils/page_parser.py
+++ b/maimai_py/utils/page_parser.py
@@ -86,7 +86,9 @@ def get_data_from_div(div) -> HTMLScore | None:
         level_elem = form.xpath(".//div[contains(@class, 'music_lv_block')]")
         score_elem = form.xpath(".//div[contains(@class, 'music_score_block')]")
 
-        title = title_elem[0].text.strip() if title_elem else ""
+        title = title_elem[0].text if title_elem else ""
+        if title != "\u3000": # Corner case for id 1422 (如月车站)
+            title = title.strip()
         level = level_elem[0].text.strip() if level_elem else ""
         level_index = get_level_index(img_src)
 


### PR DESCRIPTION
本人之前在群里反馈过一次。

经过调查分析，原因是：
如月车站这首歌，在微信网页上和在client.songs数据库里，名字都是"\u3000"即日文全角空格，而不是真正的空串。但
https://github.com/TrueRou/maimai.py/blob/cf0ac2e93d25aa031996d223596c7063559b4523/maimai_py/utils/page_parser.py#L84-L91
第89行有一个strip函数，"\u3000"作为CJK空白字符，会直接被strip干掉，所以乐曲名就从"\u3000"被变成了""。这样之后再songs.by_title()的时候就没法拿到正确的Song对象了，导致scores里会缺失这首歌的成绩。

strip我理解是为了提取html时候的鲁棒性加的，为了避免回归问题，我没有直接删除strip，而是对这首歌是不是"\u3000"做特判。我目前想到的直接解决问题且改动较小的解决方案就是这个，如果有更好的解决方案的话欢迎您直接提出！

感谢开发者的开发和维护！烦请审阅！