### PR TITLE
feat: 落雪支持使用个人API进行玩家信息、分数等查询

### DIFF
--- a/maimai_py/maimai.py
+++ b/maimai_py/maimai.py
@@ -759,16 +759,16 @@ class MaimaiClient:
             TitleServerError: Only for ArcadeProvider, maimai title server related errors, possibly network problems.
             ArcadeError: Only for ArcadeProvider, maimai response is invalid, or user id is invalid.
         """
-        # LXNSProvider's ALL scores are incomplete, which doesn't contain dx_rating and achievements, leading to sorting difficulties.
-        # In this case, we should always fetch the b35 and b15 scores for LXNSProvider.
-        b35, b15, all = [], [], []
-
-        if isinstance(provider, LXNSProvider):
-            b35, b15 = await provider.get_scores_best(identifier, self)
         all = await provider.get_scores_all(identifier, self)
 
+        if isinstance(provider, LXNSProvider) and not LXNSProvider._use_user_api(identifier):
+            # LXNSProvider's developer-level API ALL scores are incomplete, which doesn't contain dx_rating and achievements, leading to sorting difficulties.
+            # In this case, we should always fetch the b35 and b15 scores for LXNSProvider.
+            b35, b15 = await provider.get_scores_best(identifier, self)
+            all += b35 + b15
+
         maimai_scores = MaimaiScores(self)
-        return await maimai_scores.configure(all + b35 + b15)
+        return await maimai_scores.configure(all)
 
     async def regions(self, identifier: PlayerIdentifier, provider: IRegionProvider = ArcadeProvider()) -> list[PlayerRegion]:
         """Get the player's regions that they have played.

--- a/maimai_py/maimai.py
+++ b/maimai_py/maimai.py
@@ -759,16 +759,10 @@ class MaimaiClient:
             TitleServerError: Only for ArcadeProvider, maimai title server related errors, possibly network problems.
             ArcadeError: Only for ArcadeProvider, maimai response is invalid, or user id is invalid.
         """
-        all = await provider.get_scores_all(identifier, self)
-
-        if isinstance(provider, LXNSProvider) and not LXNSProvider._use_user_api(identifier):
-            # LXNSProvider's developer-level API ALL scores are incomplete, which doesn't contain dx_rating and achievements, leading to sorting difficulties.
-            # In this case, we should always fetch the b35 and b15 scores for LXNSProvider.
-            b35, b15 = await provider.get_scores_best(identifier, self)
-            all += b35 + b15
+        scores = await provider.get_scores(identifier, self)
 
         maimai_scores = MaimaiScores(self)
-        return await maimai_scores.configure(all)
+        return await maimai_scores.configure(scores)
 
     async def regions(self, identifier: PlayerIdentifier, provider: IRegionProvider = ArcadeProvider()) -> list[PlayerRegion]:
         """Get the player's regions that they have played.
@@ -836,7 +830,7 @@ class MaimaiClient:
             httpx.HTTPError: Request failed due to network issues.
         """
         # songs = await MaimaiSongs._get_or_fetch(self._client)
-        scores = await provider.get_scores_all(identifier, self)
+        scores = await provider.get_scores(identifier, self)
         maimai_plates = MaimaiPlates(self)
         return await maimai_plates._configure(plate, scores)
 

--- a/maimai_py/providers/arcade.py
+++ b/maimai_py/providers/arcade.py
@@ -72,7 +72,7 @@ class ArcadeProvider(IPlayerProvider, IScoreProvider, IRegionProvider):
             raise ArcadeError("Invalid response from the server.")
         raise InvalidPlayerIdentifierError("Player identifier credentials should be provided.")
 
-    async def get_scores_all(self, identifier: PlayerIdentifier, client: "MaimaiClient") -> list[Score]:
+    async def get_scores(self, identifier: PlayerIdentifier, client: "MaimaiClient") -> list[Score]:
         maimai_songs = await client.songs()
         if identifier.credentials and isinstance(identifier.credentials, str):
             resp: ArcadeResponse = await arcade.get_user_scores(identifier.credentials.encode(), http_proxy=self._http_proxy)
@@ -81,10 +81,6 @@ class ArcadeProvider(IPlayerProvider, IScoreProvider, IRegionProvider):
                 return [s for score in resp.data if (s := await ArcadeProvider._deser_score(score, maimai_songs))]
             raise ArcadeError("Invalid response from the server.")
         raise InvalidPlayerIdentifierError("Player identifier credentials should be provided.")
-
-    async def get_scores_best(self, identifier: PlayerIdentifier, client: "MaimaiClient") -> tuple[list[Score] | None, list[Score] | None]:
-        # Return (None, None) will call the main client to handle this, which will then fetch all scores instead
-        return None, None
 
     async def get_regions(self, identifier: PlayerIdentifier, client: "MaimaiClient") -> list[PlayerRegion]:
         if identifier.credentials and isinstance(identifier.credentials, str):

--- a/maimai_py/providers/base.py
+++ b/maimai_py/providers/base.py
@@ -62,13 +62,7 @@ class IScoreProvider:
     def _hash(self) -> str: ...
 
     @abstractmethod
-    async def get_scores_best(self, identifier: PlayerIdentifier, client: "MaimaiClient") -> tuple[list[Score] | None, list[Score] | None]:
-        """@private"""
-        # Return (None, None) will call the main client to handle this, which will then fetch all scores instead
-        return None, None
-
-    @abstractmethod
-    async def get_scores_all(self, identifier: PlayerIdentifier, client: "MaimaiClient") -> list[Score]:
+    async def get_scores(self, identifier: PlayerIdentifier, client: "MaimaiClient") -> list[Score]:
         """@private"""
         raise NotImplementedError()
 

--- a/maimai_py/providers/divingfish.py
+++ b/maimai_py/providers/divingfish.py
@@ -168,17 +168,7 @@ class DivingFishProvider(ISongProvider, IPlayerProvider, IScoreProvider, ICurveP
             additional_rating=resp_json["additional_rating"],
         )
 
-    async def get_scores_best(self, identifier: PlayerIdentifier, client: "MaimaiClient") -> tuple[list[Score], list[Score]]:
-        req_json = identifier._as_diving_fish()
-        req_json["b50"] = True
-        resp = await client._client.post(self.base_url + "query/player", json=req_json)
-        resp_json = self._check_response_player(resp)
-        return (
-            [DivingFishProvider._deser_score(score) for score in resp_json["charts"]["sd"]],
-            [DivingFishProvider._deser_score(score) for score in resp_json["charts"]["dx"]],
-        )
-
-    async def get_scores_all(self, identifier: PlayerIdentifier, client: "MaimaiClient") -> list[Score]:
+    async def get_scores(self, identifier: PlayerIdentifier, client: "MaimaiClient") -> list[Score]:
         resp = await client._client.get(self.base_url + "dev/player/records", params=identifier._as_diving_fish(), headers=self.headers)
         resp_json = self._check_response_player(resp)
         return [s for score in resp_json["records"] if (s := DivingFishProvider._deser_score(score))]

--- a/maimai_py/providers/lxns.py
+++ b/maimai_py/providers/lxns.py
@@ -49,8 +49,8 @@ class LXNSProvider(ISongProvider, IPlayerProvider, IScoreProvider, IAliasProvide
                     raise InvalidPlayerIdentifierError(resp.json()["message"])
                 identifier.friend_code = resp.json()["data"]["friend_code"]
 
-    async def _build_player_request(self, path: str, identifier: PlayerIdentifier, client: "MaimaiClient") -> tuple[str, dict[str, str]]:
-        use_user_api = identifier.credentials and isinstance(identifier.credentials, str)
+    async def _build_player_request(self, path: str, identifier: PlayerIdentifier, client: "MaimaiClient") -> tuple[str, dict[str, str], bool]:
+        use_user_api = identifier.credentials is not None and isinstance(identifier.credentials, str)
         if use_user_api:
             # user-level API takes the precedence: If personal token provided, use it first
             assert isinstance(identifier.credentials, str)
@@ -60,7 +60,7 @@ class LXNSProvider(ISongProvider, IPlayerProvider, IScoreProvider, IAliasProvide
             await self._ensure_friend_code(client, identifier)
             entrypoint = f"api/v0/maimai/player/{identifier.friend_code}/{path}"
             headers = self.headers
-        return self.base_url + entrypoint, headers
+        return self.base_url + entrypoint, headers, use_user_api
 
     @staticmethod
     def _deser_note(diff: dict, key: str) -> int:
@@ -186,7 +186,7 @@ class LXNSProvider(ISongProvider, IPlayerProvider, IScoreProvider, IAliasProvide
         maimai_icons = await client.items(PlayerIcon)
         maimai_trophies = await client.items(PlayerTrophy)
         maimai_nameplates = await client.items(PlayerNamePlate)
-        url, headers = await self._build_player_request("scores", identifier, client)
+        url, headers, _ = await self._build_player_request("scores", identifier, client)
         resp = await client._client.get(url, headers=headers)
         resp_data = self._check_response_player(resp)["data"]
         return LXNSPlayer(
@@ -213,15 +213,21 @@ class LXNSProvider(ISongProvider, IPlayerProvider, IScoreProvider, IAliasProvide
             [s for score in resp_data["dx"] if (s := LXNSProvider._deser_score(score))],
         )
 
-    async def get_scores_all(self, identifier: PlayerIdentifier, client: "MaimaiClient") -> list[Score]:
-        url, headers = await self._build_player_request("scores", identifier, client)
+    async def get_scores(self, identifier: PlayerIdentifier, client: "MaimaiClient") -> list[Score]:
+        url, headers, use_user_api = await self._build_player_request("scores", identifier, client)
         resp = await client._client.get(url, headers=headers)
         resp_data = self._check_response_player(resp)["data"]
-        return [s for score in resp_data if (s := LXNSProvider._deser_score(score))]
+        scores = [s for score in resp_data if (s := LXNSProvider._deser_score(score))]
+        if not use_user_api:
+            # LXNSProvider's developer-level API scores are incomplete, which doesn't contain dx_rating and achievements, leading to sorting difficulties.
+            # In this case, we should always fetch the b35 and b15 scores for LXNSProvider.
+            b35, b15 = await self.get_scores_best(identifier, client)
+            scores.extend(b35 + b15)
+        return scores
 
     async def update_scores(self, identifier: PlayerIdentifier, scores: list[Score], client: "MaimaiClient") -> None:
         maimai_songs = await client.songs()
-        url, headers = await self._build_player_request("scores", identifier, client)
+        url, headers, _ = await self._build_player_request("scores", identifier, client)
         scores_dict = {"scores": [json for score in scores if (json := await LXNSProvider._ser_score(score, maimai_songs))]}
         resp = await client._client.post(url, headers=headers, json=scores_dict)
         resp.raise_for_status()

--- a/maimai_py/providers/lxns.py
+++ b/maimai_py/providers/lxns.py
@@ -132,7 +132,7 @@ class LXNSProvider(ISongProvider, IPlayerProvider, IScoreProvider, IAliasProvide
             fc=FCType[score["fc"].upper()] if score["fc"] else None,
             fs=FSType[score["fs"].upper()] if score["fs"] else None,
             dx_score=score["dx_score"] if "dx_score" in score else None,
-            dx_rating=score["dx_rating"] if "dx_rating" in score else None,
+            dx_rating=int(score["dx_rating"]) if "dx_rating" in score else None,
             rate=RateType[score["rate"].upper()],
             type=SongType[score["type"].upper()],
         )

--- a/maimai_py/providers/lxns.py
+++ b/maimai_py/providers/lxns.py
@@ -60,6 +60,7 @@ class LXNSProvider(ISongProvider, IPlayerProvider, IScoreProvider, IAliasProvide
             await self._ensure_friend_code(client, identifier)
             entrypoint = f"api/v0/maimai/player/{identifier.friend_code}/{path}"
             headers = self.headers
+        entrypoint = entrypoint.removesuffix("/")
         return self.base_url + entrypoint, headers, use_user_api
 
     @staticmethod
@@ -186,7 +187,7 @@ class LXNSProvider(ISongProvider, IPlayerProvider, IScoreProvider, IAliasProvide
         maimai_icons = await client.items(PlayerIcon)
         maimai_trophies = await client.items(PlayerTrophy)
         maimai_nameplates = await client.items(PlayerNamePlate)
-        url, headers, _ = await self._build_player_request("scores", identifier, client)
+        url, headers, _ = await self._build_player_request("", identifier, client)
         resp = await client._client.get(url, headers=headers)
         resp_data = self._check_response_player(resp)["data"]
         return LXNSPlayer(

--- a/maimai_py/providers/wechat.py
+++ b/maimai_py/providers/wechat.py
@@ -61,7 +61,7 @@ class WechatProvider(IScoreProvider):
         results = await asyncio.gather(*tasks)
         return functools.reduce(operator.concat, results, [])
 
-    async def get_scores_all(self, identifier: PlayerIdentifier, client: "MaimaiClient") -> list[Score]:
+    async def get_scores(self, identifier: PlayerIdentifier, client: "MaimaiClient") -> list[Score]:
         maimai_songs = await client.songs()  # Ensure songs are loaded in cache
         if not identifier.credentials or not isinstance(identifier.credentials, Cookies):
             raise InvalidPlayerIdentifierError("Wahlap wechat cookies are required to fetch scores")

--- a/tests/test_players.py
+++ b/tests/test_players.py
@@ -1,3 +1,5 @@
+from importlib.util import find_spec
+
 import pytest
 
 from maimai_py import LXNSProvider, MaimaiClient, PlayerIdentifier
@@ -7,6 +9,12 @@ from maimai_py import LXNSProvider, MaimaiClient, PlayerIdentifier
 async def test_players_fetching(maimai: MaimaiClient, lxns: LXNSProvider):
     player = await maimai.players(PlayerIdentifier(friend_code=664994421382429), provider=lxns)
     assert player.rating > 10000
+
+    if find_spec("tests.secrets"):
+        from tests import secrets
+
+        personal_player = await maimai.players(PlayerIdentifier(credentials=secrets.lxns_personal_token), provider=lxns)
+        assert player.rating == personal_player.rating
 
 
 if __name__ == "__main__":

--- a/tests/test_scores.py
+++ b/tests/test_scores.py
@@ -1,3 +1,5 @@
+from importlib.util import find_spec
+
 import pytest
 
 from maimai_py import DivingFishProvider, LevelIndex, LXNSProvider, MaimaiClient, PlayerIdentifier
@@ -9,6 +11,12 @@ async def test_scores_fetching(maimai: MaimaiClient, lxns: LXNSProvider, divingf
     assert my_scores.rating_b35 > 10000
     score = next(my_scores.by_song(1231, level_index=LevelIndex.MASTER))
     assert score.dx_rating >= 308 if score.dx_rating else True  # 生命不詳 MASTER SSS+
+
+    if find_spec("tests.secrets"):
+        from tests import secrets
+
+        personal_scores = await maimai.scores(PlayerIdentifier(credentials=secrets.lxns_personal_token), provider=lxns)
+        assert personal_scores.rating == my_scores.rating
 
     my_scores = await maimai.scores(PlayerIdentifier(username="turou"), provider=divingfish)
     assert my_scores.rating_b35 > 10000
@@ -32,10 +40,11 @@ async def test_scores_fetching(maimai: MaimaiClient, lxns: LXNSProvider, divingf
 @pytest.mark.asyncio(scope="session")
 @pytest.mark.slow()
 async def test_scores_updating_lxns_personal(maimai: MaimaiClient, lxns: LXNSProvider, divingfish: DivingFishProvider):
-    from tests import secrets
+    if find_spec("tests.secrets"):
+        from tests import secrets
 
-    scores = await maimai.scores(PlayerIdentifier(username="turou"), provider=divingfish)
-    await maimai.updates(PlayerIdentifier(credentials=secrets.lxns_personal_token), scores.scores, provider=lxns)
+        scores = await maimai.scores(PlayerIdentifier(username="turou"), provider=divingfish)
+        await maimai.updates(PlayerIdentifier(credentials=secrets.lxns_personal_token), scores.scores, provider=lxns)
 
 
 @pytest.mark.asyncio(scope="session")


### PR DESCRIPTION
`LXNSProvider.update_scores`此前已有相关功能，允许使用[个人API](https://maimai.lxns.net/docs/api/maimai#%E4%B8%AA%E4%BA%BA-api)而非开发者API进行成绩上传：
https://github.com/TrueRou/maimai.py/blob/62308b2d82d00892680191ff1c0b31d752e468f2/maimai_py/providers/lxns.py#L214-L217
本PR将上述功能扩展到`get_player`和`get_score_all`函数，至此之后，目前为止落雪全部的三个个人API（GET player, GET scores， POST scores）均有maimai.py的对应适配了。

我个人认为这是非常重要的一个功能，我自己也非常需要它。因为并非每个人都有落雪的开发者账号，有时用户可能只是想对自己的成绩进行获取和一些自定义的分析，而不是要做出一套可以供每个人使用的公共服务。


非常感谢，烦请审阅！

注：暂时draft本PR，是因为个人API token可以通过credentials参数传入的这件事似乎并没有文档加以标注，如果不看代码很难知道这件事，我打算再加一个补充文档说明的commit。您可以先review代码相关修改。
