### PR TITLE
实现wmdx_html2record

### DIFF
--- a/maimai_py/providers/wechat.py
+++ b/maimai_py/providers/wechat.py
@@ -37,13 +37,11 @@ class WechatProvider(IScoreProvider, IPlayerProvider, IPlayerIdentifierProvider,
             is_utage = (len(song.difficulties.dx) + len(song.difficulties.standard)) == 0
             song_type = SongType.STANDARD if score.type == "SD" else SongType.DX if score.type == "DX" and not is_utage else SongType.UTAGE
             level_index = LevelIndex(score.level_index)
-            # 受网页上的内容所限，wmdx_html2record返回的的HTMLScore中不包含level，此时应从歌曲数据库中获取。
-            level = score.level if score.level is not None else song.get_difficulty(song_type, level_index).level
             if diff := song.get_difficulty(song_type, level_index):
                 rating = ScoreCoefficient(score.achievements).ra(diff.level_value)
                 return Score(
                     id=song.id,
-                    level=level,
+                    level=diff.level,
                     level_index=level_index,
                     achievements=score.achievements,
                     fc=FCType[score.fc.upper()] if score.fc else None,

--- a/maimai_py/providers/wechat.py
+++ b/maimai_py/providers/wechat.py
@@ -37,11 +37,13 @@ class WechatProvider(IScoreProvider, IPlayerProvider, IPlayerIdentifierProvider,
             is_utage = (len(song.difficulties.dx) + len(song.difficulties.standard)) == 0
             song_type = SongType.STANDARD if score.type == "SD" else SongType.DX if score.type == "DX" and not is_utage else SongType.UTAGE
             level_index = LevelIndex(score.level_index)
+            # 受网页上的内容所限，wmdx_html2record返回的的HTMLScore中不包含level，此时应从歌曲数据库中获取。
+            level = score.level if score.level is not None else song.get_difficulty(song_type, level_index).level
             if diff := song.get_difficulty(song_type, level_index):
                 rating = ScoreCoefficient(score.achievements).ra(diff.level_value)
                 return Score(
                     id=song.id,
-                    level=score.level,
+                    level=level,
                     level_index=level_index,
                     achievements=score.achievements,
                     fc=FCType[score.fc.upper()] if score.fc else None,

--- a/maimai_py/utils/page_parser.py
+++ b/maimai_py/utils/page_parser.py
@@ -32,8 +32,8 @@ class HTMLPlayer:
     rating: int
     star: int
     token: Optional[str]
-    trophy_text: Optional[str]  # 称号文本
-    trophy_rarity: Optional[str]  # 称号稀有度，直接用字符串
+    trophy_text: Optional[str]
+    trophy_rarity: Optional[str]
 
 
 def get_level_index(src: str) -> int:
@@ -169,7 +169,7 @@ def get_data_from_record_div(div) -> Optional[HTMLScore]:
     main_class = re.match(r"playlog_(\w+)_container", main.get("class"))
     assert main_class is not None
     level_index = get_level_index(main_class.group(1))
-    
+
     play_time_str = top.xpath(".//div[contains(@class, 'sub_title')]/span[2]")[0].text
     play_time = datetime.strptime(play_time_str, "%Y/%m/%d %H:%M")
     type_src = main.xpath(".//img[contains(@class, 'playlog_music_kind_icon')]")[0].get("src")
@@ -180,7 +180,7 @@ def get_data_from_record_div(div) -> Optional[HTMLScore]:
     score_elem = main.xpath(".//div[contains(@class, 'playlog_achievement_txt')]") + main.xpath(".//div[contains(@class, 'playlog_score_block')]")
     achievement_elem = main.xpath(".//img[contains(@class, 'playlog_scorerank')]")
     icon_elems = main.xpath(".//img[contains(@class, 'h_35 m_5 f_l')]")[::-1] + achievement_elem
-    
+
     score = get_score_from_elems(title_elem, None, score_elem, icon_elems, level_index, type_)
     score.play_time = play_time
     return score

--- a/maimai_py/utils/page_parser.py
+++ b/maimai_py/utils/page_parser.py
@@ -52,8 +52,8 @@ def get_level_index(src: str) -> int:
 
 
 def get_music_icon(src: str) -> str:
-    matched = re.search(r"music_icon_(.+?)\.png", src)
-    return matched.group(1) if matched and matched.group(1) != "back" else ""
+    matched = re.search(r"((?:[dcbas]{1,3}|fc|ap|sync|fs|fdx)p?)(?:lus)?\.png", src)
+    return matched.group(1) if matched else ""
 
 
 def get_dx_score(element) -> tuple[int, int]:
@@ -114,12 +114,13 @@ def get_data_from_div(div) -> Optional[HTMLScore]:
 
 
 def get_score_from_elems(title_elem, level_elem, score_elem, icon_elems, level_index: int, type_: str) -> HTMLScore:
-    title = title_elem[0].text if title_elem else ""
+    # Use `.xpath("string(.)")` to get innerText (including all children's text), rather than the text in the element itself.
+    title = title_elem[0].xpath("string(.)") if title_elem else ""
     if title != "\u3000":  # Corner case for id 1422 (如月车站)
         title = title.strip()
     level = level_elem[0].text.strip() if level_elem else ""
 
-    achievements = float(score_elem[0].text.strip()[:-1]) if score_elem else 0.0
+    achievements = float(score_elem[0].xpath("string(.)").strip()[:-1]) if score_elem else 0.0
     dx_score, full_dx_score = get_dx_score(score_elem[1] if score_elem else None)
 
     fs = fc = rate = ""
@@ -162,9 +163,43 @@ def wmdx_html2score(html: str) -> list[HTMLScore]:
     return results
 
 
+def get_data_from_record_div(div) -> Optional[HTMLScore]:
+    top, main = div.findall("./div")
+    assert top.get("class").find("playlog_top_container") != -1
+    main_class = re.match(r"playlog_(\w+)_container", main.get("class"))
+    assert main_class is not None
+    level_index = get_level_index(main_class.group(1))
+    
+    play_time_str = top.xpath(".//div[contains(@class, 'sub_title')]/span[2]")[0].text
+    play_time = datetime.strptime(play_time_str, "%Y/%m/%d %H:%M")
+    type_src = main.xpath(".//img[contains(@class, 'playlog_music_kind_icon')]")[0].get("src")
+    matched = re.search(r"_(.*).png", type_src)
+    type_ = "SD" if matched and matched.group(1) == "standard" else "DX"
+
+    title_elem = main.xpath("./div[contains(@class, 'basic_block') and contains(@class, 'break')]")
+    score_elem = main.xpath(".//div[contains(@class, 'playlog_achievement_txt')]") + main.xpath(".//div[contains(@class, 'playlog_score_block')]")
+    achievement_elem = main.xpath(".//img[contains(@class, 'playlog_scorerank')]")
+    icon_elems = main.xpath(".//img[contains(@class, 'h_35 m_5 f_l')]")[::-1] + achievement_elem
+    
+    score = get_score_from_elems(title_elem, None, score_elem, icon_elems, level_index, type_)
+    score.play_time = play_time
+    return score
+
+
 def wmdx_html2record(html: str) -> list[HTMLScore]:
-    # TODO.. implement later
-    return []
+    parser = etree.HTMLParser()
+    root = etree.fromstring(html, parser)
+
+    divs = root.xpath("//div[contains(@class, 't_l') and contains(@class, 'v_b') and contains(@class, 'p_10') and contains(@class, 'f_0')]")
+
+    results = []
+    for div in divs:
+        score = get_data_from_record_div(div)
+        if score is not None:
+            results.append(score)
+
+    del parser, root, divs
+    return results
 
 
 def _extract_player_info(

--- a/maimai_py/utils/page_parser.py
+++ b/maimai_py/utils/page_parser.py
@@ -113,7 +113,7 @@ def get_data_from_div(div) -> Optional[HTMLScore]:
         return None
 
 
-def get_score_from_elems(title_elem, level_elem, score_elem, icon_elems, level_index: int, type_: str) -> HTMLScore:
+def get_score_from_elems(title_elem, level_elem: Optional[list], score_elem, icon_elems, level_index: int, type_: str) -> HTMLScore:
     # Use `.xpath("string(.)")` to get innerText (including all children's text), rather than the text in the element itself.
     title = title_elem[0].xpath("string(.)") if title_elem else ""
     if title != "\u3000":  # Corner case for id 1422 (如月车站)

--- a/tests/sample_data/scores.html
+++ b/tests/sample_data/scores.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html lang="zh">
+<head>
+    <meta charset="UTF-8" />
+</head>
+<body oncontextmenu="return false;">
+<div class="wrapper main_wrapper t_c o_v">
+    <div class="screw_block m_15 f_15 p_s">流行&amp;动漫</div>
+    <div class="w_450 m_15 p_r f_0" >
+        <div class="music_expert_score_back pointer p_3">
+            <form action="https://maimai.wahlap.com/maimai-mobile/record/musicDetail/" method="get" accept-charset="utf-8">
+                <img src="https://maimai.wahlap.com/maimai-mobile/img/diff_expert.png" class="h_20 f_l">
+                <div class="clearfix"></div>
+                <div class="music_lv_block f_r t_c f_14">10</div>
+                <div class="music_name_block t_l f_13 break">　</div>
+                <div class="music_score_block w_112 t_r f_l f_12">100.8750%</div>
+                <div class="music_score_block w_190 t_r f_l f_12">
+                    <img src="https://maimai.wahlap.com/maimai-mobile/img/deluxscore.png" class="v_b f_l"/>
+                    989 / 1,071
+                </div>
+                <img src="https://maimai.wahlap.com/maimai-mobile/img/music_icon_sync.png?ver=1.50" class="h_30 f_r"/>
+                <img src="https://maimai.wahlap.com/maimai-mobile/img/music_icon_ap.png?ver=1.50" class="h_30 f_r"/>
+                <img src="https://maimai.wahlap.com/maimai-mobile/img/music_icon_sssp.png?ver=1.50" class="h_30 f_r"/>
+                <div class="clearfix"></div>
+            </form>
+        </div>
+        <img src="https://maimai.wahlap.com/maimai-mobile/img/music_dx.png" class="music_kind_icon "/>
+    </div>
+    <p class="scroll_point"></p>
+    <div class="screw_block m_15 f_15 p_s">niconico＆VOCALOID™</div>
+    <div class="w_450 m_15 p_r f_0" >
+        <div class="music_expert_score_back pointer p_3">
+            <form action="https://maimai.wahlap.com/maimai-mobile/record/musicDetail/" method="get" accept-charset="utf-8">
+                <img src="https://maimai.wahlap.com/maimai-mobile/img/diff_expert.png" class="h_20 f_l">
+                <div class="clearfix"></div>
+                <div class="music_lv_block f_r t_c f_14">8+</div>
+                <div class="music_name_block t_l f_13 break">花となれ</div>
+                <div class="music_score_block w_112 t_r f_l f_12">101.0000%</div>
+                <div class="music_score_block w_190 t_r f_l f_12">
+                    <img src="https://maimai.wahlap.com/maimai-mobile/img/deluxscore.png" class="v_b f_l"/>
+                    752 / 831
+                </div>
+                <img src="https://maimai.wahlap.com/maimai-mobile/img/music_icon_sync.png?ver=1.50" class="h_30 f_r"/>
+                <img src="https://maimai.wahlap.com/maimai-mobile/img/music_icon_app.png?ver=1.50" class="h_30 f_r"/>
+                <img src="https://maimai.wahlap.com/maimai-mobile/img/music_icon_sssp.png?ver=1.50" class="h_30 f_r"/>
+                <div class="clearfix"></div>
+            </form>
+        </div>
+        <img src="https://maimai.wahlap.com/maimai-mobile/img/music_dx.png" class="music_kind_icon "/>
+    </div>
+    <div class="w_450 m_15 p_r f_0" >
+        <div class="music_expert_score_back pointer p_3">
+            <form action="https://maimai.wahlap.com/maimai-mobile/record/musicDetail/" method="get" accept-charset="utf-8">
+                <img src="https://maimai.wahlap.com/maimai-mobile/img/diff_expert.png" class="h_20 f_l">
+                <div class="clearfix"></div>
+                <div class="music_lv_block f_r t_c f_14">10+</div>
+                <div class="music_name_block t_l f_13 break">ロストワンの号哭</div>
+                <div class="music_score_block w_112 t_r f_l f_12">90.4090%</div>
+                <div class="music_score_block w_190 t_r f_l f_12">
+                    <img src="https://maimai.wahlap.com/maimai-mobile/img/deluxscore.png" class="v_b f_l"/>
+                    1,079 / 1,635
+                </div>
+                <img src="https://maimai.wahlap.com/maimai-mobile/img/music_icon_sync.png?ver=1.50" class="h_30 f_r"/>
+                <img src="https://maimai.wahlap.com/maimai-mobile/img/music_icon_back.png?ver=1.50" class="h_30 f_r"/>
+                <img src="https://maimai.wahlap.com/maimai-mobile/img/music_icon_aa.png?ver=1.50" class="h_30 f_r"/>
+                <div class="clearfix"></div>
+            </form>
+        </div>
+        <img src="https://maimai.wahlap.com/maimai-mobile/img/music_standard.png" class="music_kind_icon"/>
+    </div>
+    <p class="scroll_point"></p>
+    <div class="screw_block m_15 f_15 p_s">东方Project</div>
+    <p class="scroll_point"></p>
+    <div class="screw_block m_15 f_15 p_s">其他游戏</div>
+    <div class="w_450 m_15 p_r f_0" >
+        <div class="music_expert_score_back pointer p_3">
+            <form action="https://maimai.wahlap.com/maimai-mobile/record/musicDetail/" method="get" accept-charset="utf-8">
+                <img src="https://maimai.wahlap.com/maimai-mobile/img/diff_expert.png" class="h_20 f_l">
+                <div class="clearfix"></div>
+                <div class="music_lv_block f_r t_c f_14">11</div>
+                <div class="music_name_block t_l f_13 break">Cyaegha</div>
+                <div class="music_score_block w_112 t_r f_l f_12">97.0887%</div>
+                <div class="music_score_block w_190 t_r f_l f_12">
+                    <img src="https://maimai.wahlap.com/maimai-mobile/img/deluxscore.png" class="v_b f_l"/>
+                    1,459 / 1,764
+                </div>
+                <img src="https://maimai.wahlap.com/maimai-mobile/img/music_icon_back.png?ver=1.50" class="h_30 f_r"/>
+                <img src="https://maimai.wahlap.com/maimai-mobile/img/music_icon_back.png?ver=1.50" class="h_30 f_r"/>
+                <img src="https://maimai.wahlap.com/maimai-mobile/img/music_icon_s.png?ver=1.50" class="h_30 f_r"/>
+                <div class="clearfix"></div>
+            </form>
+        </div>
+        <img src="https://maimai.wahlap.com/maimai-mobile/img/music_dx.png" class="music_kind_icon "/>
+    </div>
+    <p class="scroll_point"></p>
+    <div class="screw_block m_15 f_15 p_s">舞萌</div>
+    <div class="w_450 m_15 p_r f_0" >
+        <div class="music_expert_score_back pointer p_3">
+            <form action="https://maimai.wahlap.com/maimai-mobile/record/musicDetail/" method="get" accept-charset="utf-8">
+                <img src="https://maimai.wahlap.com/maimai-mobile/img/diff_expert.png" class="h_20 f_l">
+                <div class="clearfix"></div>
+                <div class="music_lv_block f_r t_c f_14">9</div>
+                <div class="music_name_block t_l f_13 break">シックスプラン</div>
+                <div class="music_score_block w_112 t_r f_l f_12">99.9338%</div>
+                <div class="music_score_block w_190 t_r f_l f_12">
+                    <img src="https://maimai.wahlap.com/maimai-mobile/img/deluxscore.png" class="v_b f_l"/>
+                    961 / 1,125
+                </div>
+                <img src="https://maimai.wahlap.com/maimai-mobile/img/music_icon_fs.png?ver=1.50" class="h_30 f_r"/>
+                <img src="https://maimai.wahlap.com/maimai-mobile/img/music_icon_fcp.png?ver=1.50" class="h_30 f_r"/>
+                <img src="https://maimai.wahlap.com/maimai-mobile/img/music_icon_ssp.png?ver=1.50" class="h_30 f_r"/>
+                <div class="clearfix"></div>
+            </form>
+        </div>
+        <img src="https://maimai.wahlap.com/maimai-mobile/img/music_dx.png" class="music_kind_icon "/>
+    </div>
+    <div class="w_450 m_15 p_r f_0" >
+        <div class="music_expert_score_back pointer p_3">
+            <form action="https://maimai.wahlap.com/maimai-mobile/record/musicDetail/" method="get" accept-charset="utf-8">
+                <img src="https://maimai.wahlap.com/maimai-mobile/img/diff_expert.png" class="h_20 f_l">
+                <div class="clearfix"></div>
+                <div class="music_lv_block f_r t_c f_14">9</div>
+                <div class="music_name_block t_l f_13 break">maimaiちゃんのテーマ</div>
+                <div class="music_score_block w_112 t_r f_l f_12">98.1502%</div>
+                <div class="music_score_block w_190 t_r f_l f_12">
+                    <img src="https://maimai.wahlap.com/maimai-mobile/img/deluxscore.png" class="v_b f_l"/>
+                    557 / 729
+                </div>
+                <img src="https://maimai.wahlap.com/maimai-mobile/img/music_icon_fsp.png?ver=1.50" class="h_30 f_r"/>
+                <img src="https://maimai.wahlap.com/maimai-mobile/img/music_icon_fc.png?ver=1.50" class="h_30 f_r"/>
+                <img src="https://maimai.wahlap.com/maimai-mobile/img/music_icon_sp.png?ver=1.50" class="h_30 f_r"/>
+                <div class="clearfix"></div>
+            </form>
+        </div>
+        <img src="https://maimai.wahlap.com/maimai-mobile/img/music_standard.png" class="music_kind_icon"/>
+    </div>
+    <p class="scroll_point"></p>
+    <div class="screw_block m_15 f_15 p_s">音击/中二节奏</div>
+    <div class="w_450 m_15 p_r f_0" >
+        <div class="music_expert_score_back pointer p_3">
+            <form action="https://maimai.wahlap.com/maimai-mobile/record/musicDetail/" method="get" accept-charset="utf-8">
+                <img src="https://maimai.wahlap.com/maimai-mobile/img/diff_expert.png" class="h_20 f_l">
+                <div class="clearfix"></div>
+                <div class="music_lv_block f_r t_c f_14">9</div>
+                <div class="music_name_block t_l f_13 break">STARTLINER</div>
+                <div class="music_score_block w_112 t_r f_l f_12">100.1990%</div>
+                <div class="music_score_block w_190 t_r f_l f_12">
+                    <img src="https://maimai.wahlap.com/maimai-mobile/img/deluxscore.png" class="v_b f_l"/>
+                    979 / 1,110
+                </div>
+                <img src="https://maimai.wahlap.com/maimai-mobile/img/music_icon_fdx.png?ver=1.50" class="h_30 f_r"/>
+                <img src="https://maimai.wahlap.com/maimai-mobile/img/music_icon_fcp.png?ver=1.50" class="h_30 f_r"/>
+                <img src="https://maimai.wahlap.com/maimai-mobile/img/music_icon_sss.png?ver=1.50" class="h_30 f_r"/>
+                <div class="clearfix"></div>
+            </form>
+        </div>
+        <img src="https://maimai.wahlap.com/maimai-mobile/img/music_dx.png" class="music_kind_icon "/>
+    </div>
+    <div class="w_450 m_15 p_r f_0" >
+        <div class="music_expert_score_back pointer p_3">
+            <form action="https://maimai.wahlap.com/maimai-mobile/record/musicDetail/" method="get" accept-charset="utf-8">
+                <img src="https://maimai.wahlap.com/maimai-mobile/img/diff_expert.png" class="h_20 f_l">
+                <div class="clearfix"></div>
+                <div class="music_lv_block f_r t_c f_14">10</div>
+                <div class="music_name_block t_l f_13 break">Limits</div>
+                <div class="music_score_block w_112 t_r f_l f_12">99.3390%</div>
+                <div class="music_score_block w_190 t_r f_l f_12">
+                    <img src="https://maimai.wahlap.com/maimai-mobile/img/deluxscore.png" class="v_b f_l"/>
+                    1,227 / 1,428
+                </div>
+                <img src="https://maimai.wahlap.com/maimai-mobile/img/music_icon_sync.png?ver=1.50" class="h_30 f_r"/>
+                <img src="https://maimai.wahlap.com/maimai-mobile/img/music_icon_back.png?ver=1.50" class="h_30 f_r"/>
+                <img src="https://maimai.wahlap.com/maimai-mobile/img/music_icon_ss.png?ver=1.50" class="h_30 f_r"/>
+                <div class="clearfix"></div>
+            </form>
+        </div>
+        <img src="https://maimai.wahlap.com/maimai-mobile/img/music_dx.png" class="music_kind_icon "/>
+    </div>
+</div>
+</body>
+</html>

--- a/tests/test_scores.py
+++ b/tests/test_scores.py
@@ -112,6 +112,8 @@ async def test_records_play_time_wechat():
         html_scores = wmdx_html2record(file.read())
         assert len(html_scores) > 0
         assert all(score.play_time is not None for score in html_scores)
+        s = html_scores[0]
+        assert s.title == "Re:Unknown X" and s.achievements == 98.6484 and s.fc == "" and s.fs == "sync"
 
 
 if __name__ == "__main__":

--- a/tests/test_scores.py
+++ b/tests/test_scores.py
@@ -4,7 +4,7 @@ from maimai_py.enums import LevelIndex
 from maimai_py.maimai import MaimaiClient
 from maimai_py.models import Player, PlayerIdentifier
 from maimai_py.providers import ArcadeProvider, DivingFishProvider, LXNSProvider
-from maimai_py.utils.page_parser import wmdx_html2record
+from maimai_py.utils.page_parser import wmdx_html2score, wmdx_html2record
 
 
 @pytest.mark.asyncio(scope="session")
@@ -81,7 +81,33 @@ async def test_scores_updating_divingfish(maimai: MaimaiClient, divingfish: Divi
 
 
 @pytest.mark.asyncio(scope="session")
-async def test_scores_play_time_wechat():
+async def test_scores_wechat():
+    with (open("./tests/sample_data/scores.html", "r", encoding="utf-8") as file):
+        html_scores = wmdx_html2score(file.read())
+        assert len(html_scores) == 8
+        
+        score1 = [s for s in html_scores if s.title == "花となれ"][0]
+        assert score1.achievements == 101.0000 and score1.fc == "app" and score1.fs == "sync" and score1.rate == "sssp"
+        assert score1.level == "8+" and score1.level_index == 2 and score1.type == "DX" and score1.dx_score == 752
+        score2 = [s for s in html_scores if s.title == "\u3000"][0] # corner case：如月车站
+        assert score2.achievements == 100.8750 and score2.fc == "ap" and score2.fs == "sync" and score2.rate == "sssp"
+        score3 = [s for s in html_scores if s.title == "シックスプラン"][0]
+        assert score3.achievements == 99.9338 and score3.fc == "fcp" and score3.fs == "fs" and score3.rate == "ssp"
+        score4 = [s for s in html_scores if s.title == "Cyaegha"][0]
+        assert score4.achievements == 97.0887 and score4.fc == "" and score4.fs == "" and score4.rate == "s"
+        score5 = [s for s in html_scores if s.title == "maimaiちゃんのテーマ"][0]
+        assert score5.achievements == 98.1502 and score5.fc == "fc" and score5.fs == "fsp" and score5.rate == "sp"
+        assert score5.type == "SD" and score5.dx_score == 557 and score5.level == "9" # 测一个标谱的type
+        score6 = [s for s in html_scores if s.title == "STARTLINER"][0]
+        assert score6.achievements == 100.1990 and score6.fc == "fcp" and score6.fs == "fdx" and score6.rate == "sss"
+        score7 = [s for s in html_scores if s.title == "Limits"][0]
+        assert score7.achievements == 99.3390 and score7.fc == "" and score7.fs == "sync" and score7.rate == "ss"
+        score8 = [s for s in html_scores if s.title == "ロストワンの号哭"][0]
+        assert score8.achievements == 90.4090 and score8.fc == "" and score8.fs == "sync" and score8.rate == "aa"
+
+
+@pytest.mark.asyncio(scope="session")
+async def test_records_play_time_wechat():
     with open("./tests/sample_data/record.html", "r", encoding="utf-8") as file:
         html_scores = wmdx_html2record(file.read())
         assert len(html_scores) > 0


### PR DESCRIPTION
Close #41  （应该可以关了吧）

更改行数看起来有点多，但其实只是因为做了重构。Review的时候建议分commit进行，这样好看一点：
9437b5c, 93fcfe6 : 先是对原有的`wmdx_html2score`进行了亿些重构，以便后面正式开工。然后为了防止我改炸，我自己加了一个测试样例进去。
09a4d17 : 实现`wmdx_html2record`，其中逻辑上能和`wmdx_html2score`共用的部分尽量进行了共用。