### PR TITLE
fix: Generic type usage error

### DIFF
--- a/maimai_py/maimai.py
+++ b/maimai_py/maimai.py
@@ -35,7 +35,7 @@ class MaimaiItems(Generic[PlayerItemType]):
             if await cache_obj.get("provider", None, namespace=self._namespace) is not None:
                 return self
         # Really assign the unset provider to the default one.
-        provider = LXNSProvider() if PlayerItemType in [PlayerIcon, PlayerNamePlate, PlayerFrame] else LocalProvider()
+        provider = LXNSProvider() if self._namespace in ["icons", "nameplates", "frames"] else LocalProvider()
         # Check if the current provider hash is different from the previous one, which means we need to reconfigure.
         current_provider_hash = provider._hash()
         previous_provider_hash = await cache_obj.get("provider", "", namespace=self._namespace)


### PR DESCRIPTION
## 问题描述

**原始代码**

```python
provider = LXNSProvider() if PlayerItemType in [PlayerIcon, PlayerNamePlate, PlayerFrame] else LocalProvider()
```
其中 `PlayerItemType = TypeVar("PlayerItemType", bound=PlayerItem)` 

这行代码在运行时逻辑上是错误的。因为 `PlayerItemType` 作为 TypeVar 对象永远不可能等于 PlayerItem 的子类。所以这个判断条件永远为 False，导致它总是回退到 LocalProvider()

## 复现

使用 `maimai_client.players()` ，其中 provider 使用 `LXNSProvider`，观察到用户收藏品资料部分缺失：

<img width="836" height="403" alt="image" src="https://github.com/user-attachments/assets/24a0c1c0-a611-4448-b838-9053eb65b5c8" />

## 解决方案

由于类提供了 `_namespace` ，在不引入类属性的情况下，我们可以直接使用：

```python
provider = LXNSProvider() if self._namespace in ["icons", "nameplates", "frames"] else LocalProvider()
```

应用上述代码后，问题得以解决

<img width="842" height="391" alt="image" src="https://github.com/user-attachments/assets/dfc83f7e-06d4-43d5-b2bf-f93ebb3153e5" />
