### PR TITLE
fix: 设置对手成功后，会被重定向到`/maimai-mobile/friend/`，这是设置对手成功的情况，不应该抛异常。

### DIFF
--- a/maimai_py/providers/wechat.py
+++ b/maimai_py/providers/wechat.py
@@ -189,6 +189,9 @@ class WechatProvider(IScoreProvider, IPlayerProvider, IPlayerIdentifierProvider,
             cookies=self._ensure_cookies(identifier),
             data={"idx": rival.friend_code, "token": rival.token},
         )
+        if resp.status_code == 302 and resp.headers.get("location", "").rstrip("/").endswith("/maimai-mobile/friend"):
+            # 返回302、重定向到friend主页，是成功的情况。此时不应该抛出异常
+            return
         resp.raise_for_status()
 
     @retry(stop=stop_after_attempt(3), retry=retry_if_exception_type(RequestError), reraise=True)
@@ -198,6 +201,9 @@ class WechatProvider(IScoreProvider, IPlayerProvider, IPlayerIdentifierProvider,
             cookies=self._ensure_cookies(identifier),
             data={"idx": rival.friend_code, "token": rival.token},
         )
+        if resp.status_code == 302 and resp.headers.get("location", "").rstrip("/").endswith("/maimai-mobile/friend"):
+            # 返回302、重定向到friend主页，是成功的情况。此时不应该抛出异常
+            return
         resp.raise_for_status()
 
     @retry(stop=stop_after_attempt(3), retry=retry_if_exception_type(RequestError), reraise=True)


### PR DESCRIPTION
之前的代码
https://github.com/TrueRou/maimai.py/blob/73b9840afb2fa8c276e0294fd4d5b95a1535a627/maimai_py/providers/wechat.py#L185-L192
使用的是`resp.raise_for_status()`。
然而，根据实际行为测试与对httpx的源码分析（如下图），`httpx.Response.raise_for_status()`在返回302的情况下，也会认为是请求失败从而抛出异常。
<img width="1139" height="863" alt="image" src="https://github.com/user-attachments/assets/d5541be5-a36b-4896-96a8-8f1ecb69ebe0" />

本PR修复了这一行为，当返回码是302且重定向目标是`/maimai-mobile/friend`时，函数正常返回、不去调用`resp.raise_for_status()`抛异常。

感谢review！
